### PR TITLE
include meta.json in archive.tar.gz

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ cd `dirname $0`
 ## using `python -m PyInastaller` as opposed to `pyinstaller` as the former
 ## runs in the venv and the latter does not
 python -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz ./dist/main
+tar -czvf dist/archive.tar.gz ./dist/main meta.json
 # To run locally, we need meta.json in the same directory. So, add to dist/ a
 # symlink that goes one directory up to meta.json
 ln -s -f ../meta.json dist


### PR DESCRIPTION
This should help with testing things out as a local module. For code deployed via the modular registry, this shouldn't change anything.

I've run `make dist/archive.tar.gz`, and it builds the tarball correctly.